### PR TITLE
fix the curl usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ mvn clean install
     or 
 
     curl http://<HOST_PORT_ADDRESS>/greeting
-    curl http://<HOST_PORT_ADDRESS>/greeting -d name=Bruno
+    curl http://<HOST_PORT_ADDRESS>/greeting?name=Bruno
     ```
  
  


### PR DESCRIPTION
The `/greeting` endpoint accepts GET requests with a query parameter
of `name`. The README used to use `curl -d` to pass that parameter,
but `curl -d` makes the request a POST and puts the parameter
into the request body. This commit fixes that.