### PR TITLE
upgrade Fabric8 Maven plugin to the 3.2 series

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <version.wildfly.swarm>2017.3.3</version.wildfly.swarm>
     <version.resteasy>3.0.19.Final</version.resteasy>
 
-    <fabric8.maven.plugin.version>3.1.92</fabric8.maven.plugin.version>
+    <fabric8.maven.plugin.version>3.2.28</fabric8.maven.plugin.version>
 
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
@@ -50,7 +50,7 @@
     <dependencies>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>bom-all</artifactId>
+        <artifactId>bom</artifactId>
         <version>${version.wildfly.swarm}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -89,20 +89,6 @@
       <groupId>com.jayway.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>1.7.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
-      <version>2.1.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-model</artifactId>
-      <version>1.0.67</version>
       <scope>test</scope>
     </dependency>
 
@@ -150,40 +136,14 @@
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-plugin</artifactId>
-        <version>${fabric8.maven.plugin.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>resource</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <generator>
-            <includes>
-              <include>wildfly-swarm</include>
-            </includes>
-          </generator>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 
   <profiles>
     <profile>
       <id>openshift</id>
-      <properties>
-        <maven.failsafe.skip>false</maven.failsafe.skip>
-        <maven.surefire.skip>true</maven.surefire.skip>
-      </properties>
       <build>
         <plugins>
-
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
@@ -219,7 +179,7 @@
               <execution>
                 <goals>
                   <goal>resource</goal>
-                  <goal>build</goal>  <!-- additional step here -->
+                  <goal>build</goal>
                 </goals>
               </execution>
             </executions>
@@ -228,6 +188,10 @@
                 <includes>
                   <include>wildfly-swarm</include>
                 </includes>
+                <excludes>
+                  <!-- it isn't needed and it fails the build because it doesn't support S2I -->
+                  <exclude>webapp</exclude>
+                </excludes>
               </generator>
             </configuration>
           </plugin>

--- a/src/test/java/io/openshift/booster/OpenshiftIT.java
+++ b/src/test/java/io/openshift/booster/OpenshiftIT.java
@@ -1,12 +1,9 @@
 package io.openshift.booster;
 
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
@@ -15,8 +12,6 @@ import static org.hamcrest.Matchers.containsString;
 /**
  * @author Heiko Braun
  */
-@RunWith(Arquillian.class)
-@RunAsClient
 public class OpenshiftIT {
 
     private static final String APPLICATION_NAME = System.getProperty("app.name");
@@ -61,10 +56,10 @@ public class OpenshiftIT {
         given().
             param("name", "Peter").
         expect().
-                statusCode(200).
-                body(containsString("Hello, Peter!")).
-            when().
-                get(API_ENDPOINT);
+            statusCode(200).
+            body(containsString("Hello, Peter!")).
+        when().
+            get(API_ENDPOINT);
     }
 }
 


### PR DESCRIPTION
The Fabric8 Maven plugin 3.1 adds an ImageStream definition
to target/classes/META-INF/fabric8/openshift.yml, which means
that the OpenShiftTestAssistant deletes it after the test.
This then causes failures in a follow-up fabric8:deploy.

The Fabric8 Maven plugin 3.2 doesn't do that, which is good.
However, it tries to apply the "webapp" generator, which fails
the build because this generator doesn't support S2I. Fortunately,
this generator isn't needed, so it can be just excluded.

Also contains other small improvements of the POM.