### PR TITLE
update booster parent and Swarm to latest releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.openshift</groupId>
     <artifactId>booster-parent</artifactId>
-    <version>5</version>
+    <version>8</version>
   </parent>
 
   <groupId>io.openshift.booster</groupId>
@@ -34,7 +34,7 @@
   <description>WildFly Swarm - Rest</description>
 
   <properties>
-    <version.wildfly.swarm>2017.7.0</version.wildfly.swarm>
+    <version.wildfly.swarm>2017.8.1</version.wildfly.swarm>
     <version.resteasy>3.0.19.Final</version.resteasy>
   </properties>
 
@@ -132,9 +132,6 @@
                 </excludes>
               </generator>
               <enricher>
-                <includes>
-                  <include>wildfly-swarm-health-check</include>
-                </includes>
                 <config>
                   <wildfly-swarm-health-check>
                     <path>/</path>


### PR DESCRIPTION
This commit also removes an explicit `<include>`
of the `wildfly-swarm-health-check` enricher.
This is because:

- Including it is no longer necessary, latest booster
  parent prescribes Fabric8 Maven plugin 3.5.22 which
  applies this enricher automatically by default.
- An explicit include also changes order of enricher
  application. If a health check enricher is applied
  before an enricher that generates default `deployment.yml`,
  the health check isn't actually added at all. Which
  is exactly what happened here.