### PR TITLE
#4500 Modifying application.yaml as required by openshift.io osio pipeline library

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -10,6 +10,14 @@ metadata:
     description: >-
       The REST API Level 0 Mission provides a basic example of mapping business operations to a remote procedure call endpoint over HTTP using a REST framework.
 parameters:
+- name: SUFFIX_NAME
+  description: The suffix name for the template objects
+  displayName: Suffix name
+  value: ''
+- name: RELEASE_VERSION
+  description: The release version number of application
+  displayName: Release version
+  value: 1.0.0
 - name: SOURCE_REPOSITORY_URL
   description: The source URL for the application
   displayName: Source URL
@@ -35,7 +43,9 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: thorntail-rest-http
+    name: thorntail-rest-http${SUFFIX_NAME}
+    labels:
+      version: ${RELEASE_VERSION}
   spec: {}
 - apiVersion: v1
   kind: ImageStream
@@ -50,12 +60,14 @@ objects:
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: thorntail-rest-http
+    name: thorntail-rest-http-s2i${SUFFIX_NAME}
+    labels:
+      version: ${RELEASE_VERSION}
   spec:
     output:
       to:
         kind: ImageStreamTag
-        name: thorntail-rest-http:latest
+        name: 'thorntail-rest-http${SUFFIX_NAME}:${RELEASE_VERSION}'
     postCommit: {}
     resources: {}
     source:
@@ -68,9 +80,9 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: runtime:latest
+          name: 'runtime:latest'
         incremental: true
-        env:    
+        env:
         - name: MAVEN_ARGS_APPEND
           value: "-pl ${SOURCE_REPOSITORY_DIR}"
         - name: ARTIFACT_DIR
@@ -92,7 +104,8 @@ objects:
       expose: "true"
       app: thorntail-rest-http
       group: io.openshift.booster
-    name: thorntail-rest-http
+      version: ${RELEASE_VERSION}
+    name: thorntail-rest-http${SUFFIX_NAME}
   spec:
     ports:
     - name: http
@@ -108,7 +121,8 @@ objects:
     labels:
       app: thorntail-rest-http
       group: io.openshift.booster
-    name: thorntail-rest-http
+      version: ${RELEASE_VERSION}
+    name: thorntail-rest-http${SUFFIX_NAME}
   spec:
     replicas: 1
     revisionHistoryLimit: 2
@@ -124,6 +138,7 @@ objects:
         labels:
           app: thorntail-rest-http
           group: io.openshift.booster
+          version: ${RELEASE_VERSION}
       spec:
         containers:
         - env:
@@ -131,7 +146,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: thorntail-rest-http:latest
+          image: ""
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -166,7 +181,7 @@ objects:
         - thorntail
         from:
           kind: ImageStreamTag
-          name: thorntail-rest-http:latest
+          name: 'thorntail-rest-http${SUFFIX_NAME}:${RELEASE_VERSION}'
       type: ImageChange
 - apiVersion: v1
   kind: Route
@@ -174,10 +189,11 @@ objects:
     labels:
       app: thorntail-rest-http
       group: io.openshift.booster
-    name: thorntail-rest-http
+      version: ${RELEASE_VERSION}
+    name: thorntail-rest-http${SUFFIX_NAME}
   spec:
     port:
       targetPort: 8080
     to:
       kind: Service
-      name: thorntail-rest-http
+      name: thorntail-rest-http${SUFFIX_NAME}


### PR DESCRIPTION
openshiftio/openshift.io#4500
This changed include the below which is required by osio pipeline library (https://github.com/fabric8io/osio-pipeline) :

1. Adds parameter - RELEASE_VERSION which is basically the
build number and will be used to differentiate between
the resources of the particular build.
2. Adds parameter - SUFFIX_NAME which is an identifier to
differentiate between the master build or other branches.
More like a master build or PR build. So whenever there is
a change in the resources of a particular branch, it applies
to the resource of that branch only. The SUFFIX_NAME variable
is used in the name of all resources.
